### PR TITLE
feat: enhance quick entry - default remember checkbox and support amount units

### DIFF
--- a/app/services/quick_entry_parser.rb
+++ b/app/services/quick_entry_parser.rb
@@ -4,10 +4,11 @@ class QuickEntryParser
   #   {payer} 支付 {description} {amount}
   #   {payer} {description} {amount}
   #   {description} {amount}
-  FULL_PATTERN = /\A(?:紀錄|記錄)\s*(.+?)\s*支付\s*(.+?)\s*(\d+(?:\.\d+)?)\z/
-  VERB_PATTERN = /\A(.+?)\s*支付\s*(.+?)\s*(\d+(?:\.\d+)?)\z/
-  SHORT_PATTERN = /\A(\S+)\s+(.+?)\s+(\d+(?:\.\d+)?)\z/
-  MINIMAL_PATTERN = /\A(.+?)\s*(\d+(?:\.\d+)?)\z/
+  AMOUNT_UNIT = /(?:元|塊|圓)?/
+  FULL_PATTERN = /\A(?:紀錄|記錄)\s*(.+?)\s*支付\s*(.+?)\s*(\d+(?:\.\d+)?)#{AMOUNT_UNIT}\z/
+  VERB_PATTERN = /\A(.+?)\s*支付\s*(.+?)\s*(\d+(?:\.\d+)?)#{AMOUNT_UNIT}\z/
+  SHORT_PATTERN = /\A(\S+)\s+(.+?)\s+(\d+(?:\.\d+)?)#{AMOUNT_UNIT}\z/
+  MINIMAL_PATTERN = /\A(.+?)\s*(\d+(?:\.\d+)?)#{AMOUNT_UNIT}\z/
 
   def self.parse(input)
     text = input.to_s.strip.gsub(/\s+/, " ")

--- a/app/views/quick_entry/create.html.erb
+++ b/app/views/quick_entry/create.html.erb
@@ -35,7 +35,7 @@
       </select>
       <% unless @category_matched %>
         <label class="flex items-center gap-2 mt-2">
-          <%= f.check_box :remember_category, class: "rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" %>
+          <%= f.check_box :remember_category, { checked: true, class: "rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" } %>
           <span class="text-xs text-slate-500">記住「<%= @description_keyword %>」對應此類別</span>
         </label>
       <% end %>

--- a/app/views/quick_entry_confirmations/show.html.erb
+++ b/app/views/quick_entry_confirmations/show.html.erb
@@ -34,7 +34,7 @@
       </select>
       <% if @description_keyword.present? %>
         <label class="flex items-center gap-2 mt-2">
-          <%= f.check_box :remember_category, class: "rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" %>
+          <%= f.check_box :remember_category, { checked: true, class: "rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" } %>
           <span class="text-xs text-slate-500">記住「<%= @description_keyword %>」對應此類別</span>
         </label>
       <% end %>

--- a/spec/services/quick_entry_parser_spec.rb
+++ b/spec/services/quick_entry_parser_spec.rb
@@ -62,6 +62,26 @@ RSpec.describe QuickEntryParser do
       expect(result).to eq({ payer: nil, description: "停車費", amount: 100.0 })
     end
 
+    it "parses amount with 元 unit: 午餐150元" do
+      result = QuickEntryParser.parse("午餐150元")
+      expect(result).to eq({ payer: nil, description: "午餐", amount: 150.0 })
+    end
+
+    it "parses amount with 元 unit and space: 午餐 150元" do
+      result = QuickEntryParser.parse("午餐 150元")
+      expect(result).to eq({ payer: nil, description: "午餐", amount: 150.0 })
+    end
+
+    it "parses amount with 塊 unit: 咖啡80塊" do
+      result = QuickEntryParser.parse("咖啡80塊")
+      expect(result).to eq({ payer: nil, description: "咖啡", amount: 80.0 })
+    end
+
+    it "parses amount with 元 unit in full format: 紀錄 Jerry 支付 午餐 150元" do
+      result = QuickEntryParser.parse("紀錄 Jerry 支付 午餐 150元")
+      expect(result).to eq({ payer: "Jerry", description: "午餐", amount: 150.0 })
+    end
+
     it "returns nil for unparseable input" do
       result = QuickEntryParser.parse("hello")
       expect(result).to be_nil


### PR DESCRIPTION
Closes #20

## Changes

- Default remember_category checkbox to checked when category cannot be matched
- Support amount units (元/塊/圓) in QuickEntryParser, e.g. "午餐150元"
- Add parser tests for amount unit suffixes

Generated with [Claude Code](https://claude.ai/code)